### PR TITLE
#2 add BulkHandler.flush(channel) and call it

### DIFF
--- a/src/main/java/org/xbib/elasticsearch/websocket/action/bulk/BulkFlushAction.java
+++ b/src/main/java/org/xbib/elasticsearch/websocket/action/bulk/BulkFlushAction.java
@@ -25,6 +25,6 @@ public class BulkFlushAction extends BulkHandler {
 
     @Override
     public void handleRequest(final InteractiveRequest request, final InteractiveChannel channel) {
-        this.flush();
+        this.flush(channel);
     }
 }

--- a/src/main/java/org/xbib/elasticsearch/websocket/action/bulk/BulkHandler.java
+++ b/src/main/java/org/xbib/elasticsearch/websocket/action/bulk/BulkHandler.java
@@ -223,6 +223,18 @@ public class BulkHandler extends BaseInteractiveHandler {
     }
 
     /**
+     * Flushes open bulk actions
+     */
+    public synchronized void flush(InteractiveChannel channel) {
+        if (closed) {
+            return;
+        }
+        if (bulk.size() > 0) {
+            execute(channel);
+        }
+    }
+
+    /**
      * Closes the processor. If flushing by time is enabled, then its shutdown.
      * Any remaining bulk actions are flushed.
      */


### PR DESCRIPTION
When flushing, provide a channel so that a bulk response is returned to the websocket client.
